### PR TITLE
[Bug fix] Removes default database relation from smf and amf to mongo

### DIFF
--- a/render_bundle/bundles.py
+++ b/render_bundle/bundles.py
@@ -115,6 +115,12 @@ class SDCore(CharmBundle):
                     app_2_relation_name="database",
                 ),
                 Relation(
+                    app_1_name=smf.name,
+                    app_2_name=grafana_agent.name,
+                    app_1_relation_name="metrics-endpoint",
+                    app_2_relation_name="metrics-endpoint",
+                ),
+                Relation(
                     app_1_name=udm.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
@@ -233,6 +239,12 @@ class SDCoreControlPlane(CharmBundle):
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
                     app_2_relation_name="fiveg-nrf",
+                ),
+                Relation(
+                    app_1_name=smf.name,
+                    app_2_name=grafana_agent.name,
+                    app_1_relation_name="metrics-endpoint",
+                    app_2_relation_name="metrics-endpoint",
                 ),
                 Relation(
                     app_1_name=smf.name,

--- a/render_bundle/bundles.py
+++ b/render_bundle/bundles.py
@@ -63,13 +63,7 @@ class SDCore(CharmBundle):
                 Relation(
                     app_1_name=amf.name,
                     app_2_name=mongodb.name,
-                    app_1_relation_name="default-database",
-                    app_2_relation_name="database",
-                ),
-                Relation(
-                    app_1_name=amf.name,
-                    app_2_name=mongodb.name,
-                    app_1_relation_name="amf-database",
+                    app_1_relation_name="database",
                     app_2_relation_name="database",
                 ),
                 Relation(
@@ -117,13 +111,7 @@ class SDCore(CharmBundle):
                 Relation(
                     app_1_name=smf.name,
                     app_2_name=mongodb.name,
-                    app_1_relation_name="default-database",
-                    app_2_relation_name="database",
-                ),
-                Relation(
-                    app_1_name=smf.name,
-                    app_2_name=mongodb.name,
-                    app_1_relation_name="smf-database",
+                    app_1_relation_name="database",
                     app_2_relation_name="database",
                 ),
                 Relation(
@@ -201,13 +189,7 @@ class SDCoreControlPlane(CharmBundle):
                 Relation(
                     app_1_name=amf.name,
                     app_2_name=mongodb.name,
-                    app_1_relation_name="default-database",
-                    app_2_relation_name="database",
-                ),
-                Relation(
-                    app_1_name=amf.name,
-                    app_2_name=mongodb.name,
-                    app_1_relation_name="amf-database",
+                    app_1_relation_name="database",
                     app_2_relation_name="database",
                 ),
                 Relation(
@@ -255,13 +237,7 @@ class SDCoreControlPlane(CharmBundle):
                 Relation(
                     app_1_name=smf.name,
                     app_2_name=mongodb.name,
-                    app_1_relation_name="default-database",
-                    app_2_relation_name="database",
-                ),
-                Relation(
-                    app_1_name=smf.name,
-                    app_2_name=mongodb.name,
-                    app_1_relation_name="smf-database",
+                    app_1_relation_name="database",
                     app_2_relation_name="database",
                 ),
                 Relation(

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore.yaml
@@ -82,6 +82,8 @@ relations:
     - nrf:fiveg-nrf
   - - smf:database
     - mongodb-k8s:database
+  - - smf:metrics-endpoint
+    - grafana-agent-k8s:metrics-endpoint
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf
   - - udr:fiveg_nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore.yaml
@@ -64,9 +64,7 @@ applications:
 relations:
   - - amf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - amf:default-database
-    - mongodb-k8s:database
-  - - amf:amf-database
+  - - amf:database
     - mongodb-k8s:database
   - - amf:metrics-endpoint
     - grafana-agent-k8s:metrics-endpoint
@@ -82,9 +80,7 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - smf:default-database
-    - mongodb-k8s:database
-  - - smf:smf-database
+  - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane.yaml
@@ -75,6 +75,8 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
+  - - smf:metrics-endpoint
+    - grafana-agent-k8s:metrics-endpoint
   - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane.yaml
@@ -59,9 +59,7 @@ applications:
 relations:
   - - amf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - amf:default-database
-    - mongodb-k8s:database
-  - - amf:amf-database
+  - - amf:database
     - mongodb-k8s:database
   - - amf:metrics-endpoint
     - grafana-agent-k8s:metrics-endpoint
@@ -77,9 +75,7 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - smf:default-database
-    - mongodb-k8s:database
-  - - smf:smf-database
+  - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane_local.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane_local.yaml
@@ -84,6 +84,8 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
+  - - smf:metrics-endpoint
+    - grafana-agent-k8s:metrics-endpoint
   - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane_local.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_control_plane_local.yaml
@@ -68,9 +68,7 @@ applications:
 relations:
   - - amf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - amf:default-database
-    - mongodb-k8s:database
-  - - amf:amf-database
+  - - amf:database
     - mongodb-k8s:database
   - - amf:metrics-endpoint
     - grafana-agent-k8s:metrics-endpoint
@@ -86,9 +84,7 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - smf:default-database
-    - mongodb-k8s:database
-  - - smf:smf-database
+  - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_local.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_local.yaml
@@ -95,6 +95,8 @@ relations:
     - nrf:fiveg-nrf
   - - smf:database
     - mongodb-k8s:database
+  - - smf:metrics-endpoint
+    - grafana-agent-k8s:metrics-endpoint
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf
   - - udr:fiveg_nrf

--- a/render_bundle/tests/unit/src/expected_bundle_sdcore_local.yaml
+++ b/render_bundle/tests/unit/src/expected_bundle_sdcore_local.yaml
@@ -77,9 +77,7 @@ applications:
 relations:
   - - amf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - amf:default-database
-    - mongodb-k8s:database
-  - - amf:amf-database
+  - - amf:database
     - mongodb-k8s:database
   - - amf:metrics-endpoint
     - grafana-agent-k8s:metrics-endpoint
@@ -95,9 +93,7 @@ relations:
     - mongodb-k8s:database
   - - smf:fiveg_nrf
     - nrf:fiveg-nrf
-  - - smf:default-database
-    - mongodb-k8s:database
-  - - smf:smf-database
+  - - smf:database
     - mongodb-k8s:database
   - - udm:fiveg_nrf
     - nrf:fiveg-nrf


### PR DESCRIPTION
# Description

Removes default database relation from smf and amf to mongo. Depends on:
- https://github.com/canonical/sdcore-amf-operator/pull/8
- https://github.com/canonical/sdcore-smf-operator/pull/6

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
