### PR TITLE
[feat] Uses beta release of self-signed-certificates operator

### DIFF
--- a/render_bundle/applications.py
+++ b/render_bundle/applications.py
@@ -238,5 +238,5 @@ class SelfSignedCertificates(Application):
         super().__init__(
             name="self-signed-certificates",
             charm="self-signed-certificates",
-            channel="edge",
+            channel="beta",
         )


### PR DESCRIPTION
# Description

Since the [self-signed-certificates operator](https://charmhub.io/self-signed-certificates) is now available in beta, we should have the SD-Core bundles use this more stable release (vs. edge).

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
