### PR TITLE
docs: Combines information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/sdcore-control-plane/badge.svg)](https://charmhub.io/sdcore-control-plane)
 [![CharmHub Badge](https://charmhub.io/sdcore-user-plane/badge.svg)](https://charmhub.io/sdcore-user-plane)
 
-This project contains charm bundles for the SD-Core. Bundles are available on Charmhub:
-- [sdcore](https://charmhub.io/sdcore)
-- [sdcore-control-plane](https://charmhub.io/sdcore-user-plane)
-- [sdcore-user-plane](https://charmhub.io/sdcore-control-plane)
+This project contains charm bundles for SD-Core. 
 
 ### Bundle generation
 


### PR DESCRIPTION
# Description

With the badges now in the README.md, we have redundante information regarding links to SD-Core bundles in Charmhub. This PR removes the unnecessary links and only keeps the badges which are clickable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
