### PR TITLE
feat: Uses subdomain routing mode in Traefik

### DIFF
--- a/render_bundle/applications.py
+++ b/render_bundle/applications.py
@@ -262,4 +262,5 @@ class Traefik(Application):
             charm="traefik-k8s",
             channel="latest/stable",
             trust=True,
+            options={"routing_mode": "subdomain"},
         )

--- a/render_bundle/lib/bundle.yaml.j2
+++ b/render_bundle/lib/bundle.yaml.j2
@@ -18,6 +18,12 @@ applications:
       {{ resource.name }}: {{ resource.value }}
       {%- endfor %}
     {%- endif %}
+    {%- if application.options %}
+    options:
+      {%- for option in application.options %}
+      {{option}}: {{ application.options[option] }}
+      {%- endfor %}
+    {%- endif %}
   {%- endfor %}
 {%- if relations %}
 relations:

--- a/render_bundle/lib/charm_bundle_generator.py
+++ b/render_bundle/lib/charm_bundle_generator.py
@@ -37,6 +37,7 @@ class Application(BaseModel):
     scale: int = 1
     trust: bool = False
     channel: Optional[str] = None
+    options: Optional[dict[str, str]] = None
 
 
 class Relation(BaseModel):

--- a/render_bundle/tests/unit/lib/expected_bundle_local.yaml
+++ b/render_bundle/tests/unit/lib/expected_bundle_local.yaml
@@ -18,6 +18,9 @@ applications:
     resources:
       container-image-3: whatever-image-3:1111
       container-image-4: whatever-image-4:2222
+    options:
+      option-1: value-1
+      option-2: value-2
 relations:
   - - app-1-name:banana
     - app-2-name:fruit

--- a/render_bundle/tests/unit/lib/test_charm_bundle_generator.py
+++ b/render_bundle/tests/unit/lib/test_charm_bundle_generator.py
@@ -74,6 +74,7 @@ class TestRenderBundle(unittest.TestCase):
                 Resource(name="container-image-3", value="whatever-image-3:1111"),
                 Resource(name="container-image-4", value="whatever-image-4:2222"),
             ],
+            options={"option-1": "value-1", "option-2": "value-2"},
         )
         relation_1 = Relation(
             app_1_name=app_1.name,


### PR DESCRIPTION
# Description

The NMS currently does not work when using the "path" routing mode in traefik. Only the "subdomain" routing mode is currently supported. This PR makes it so that the SD-Core bundles deploy Traefik with the subdomain routing mode. Our Charmed 5G documentation should also reflect this by configuring a `external_hostname` in the traefik configuration.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
