### PR TITLE
docs: Adds virtual env creation before installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project contains charm bundles for SD-Core.
 To render a bundle and output it in the bundle directory (e.g., `SDCORE_USER_PLANE`):
 
 ```bash
+python3 -m venv env
+source env/bin/activate
 pip3 install -r render_bundle/requirements.txt
 python3 render_bundle/render_bundle.py --bundle_variant SDCORE_USER_PLANE --output_file bundle/bundle.yaml
 ```


### PR DESCRIPTION
# Description

Adds virtual env creation before installing dependencies. This makes it so that users don't install dependencies in their root python environment.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
