### PR TITLE
chore: Rename SD-Core bundles by adding -k8s as a suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core bundles
-[![CharmHub Badge](https://charmhub.io/sdcore/badge.svg)](https://charmhub.io/sdcore)
-[![CharmHub Badge](https://charmhub.io/sdcore-control-plane/badge.svg)](https://charmhub.io/sdcore-control-plane)
-[![CharmHub Badge](https://charmhub.io/sdcore-user-plane/badge.svg)](https://charmhub.io/sdcore-user-plane)
+# SD-Core bundles for K8s
+[![CharmHub Badge](https://charmhub.io/sdcore-k8s/badge.svg)](https://charmhub.io/sdcore-k8s)
+[![CharmHub Badge](https://charmhub.io/sdcore-control-plane-k8s/badge.svg)](https://charmhub.io/sdcore-control-plane-k8s)
+[![CharmHub Badge](https://charmhub.io/sdcore-user-plane-k8s/badge.svg)](https://charmhub.io/sdcore-user-plane-k8s)
 
 This project contains charm bundles for SD-Core. 
 

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,1 +1,1 @@
-# SD-Core Bundle
+# SD-Core Bundle for K8s

--- a/render_bundle/applications.py
+++ b/render_bundle/applications.py
@@ -7,7 +7,7 @@ from lib.charm_bundle_generator import Application, Resource
 
 
 class AMF(Application):
-    """SD-Core AMF Application."""
+    """SD-Core AMF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -18,7 +18,7 @@ class AMF(Application):
         ]
         super().__init__(
             name="amf",
-            charm="sdcore-amf_ubuntu-22.04-amd64.charm" if local else "sdcore-amf",
+            charm="sdcore-amf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-amf-k8s",
             trust=True,
             channel=None if local else channel,
             resources=resources if local else None,
@@ -26,7 +26,7 @@ class AMF(Application):
 
 
 class AUSF(Application):
-    """SD-Core AUSF Application."""
+    """SD-Core AUSF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -37,14 +37,14 @@ class AUSF(Application):
         ]
         super().__init__(
             name="ausf",
-            charm="sdcore-ausf_ubuntu-22.04-amd64.charm" if local else "sdcore-ausf",
+            charm="sdcore-ausf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-ausf-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class NMS(Application):
-    """SD-Core NMS Application."""
+    """SD-Core NMS Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -55,14 +55,14 @@ class NMS(Application):
         ]
         super().__init__(
             name="nms",
-            charm="sdcore-nms_ubuntu-22.04-amd64.charm" if local else "sdcore-nms",
+            charm="sdcore-nms-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-nms-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class NRF(Application):
-    """SD-Core NRF Application."""
+    """SD-Core NRF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -73,14 +73,14 @@ class NRF(Application):
         ]
         super().__init__(
             name="nrf",
-            charm="sdcore-nrf_ubuntu-22.04-amd64.charm" if local else "sdcore-nrf",
+            charm="sdcore-nrf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-nrf-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class NSSF(Application):
-    """SD-Core NSSF Application."""
+    """SD-Core NSSF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -91,14 +91,14 @@ class NSSF(Application):
         ]
         super().__init__(
             name="nssf",
-            charm="sdcore-nssf_ubuntu-22.04-amd64.charm" if local else "sdcore-nssf",
+            charm="sdcore-nssf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-nssf-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class PCF(Application):
-    """SD-Core PCF Application."""
+    """SD-Core PCF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -109,14 +109,14 @@ class PCF(Application):
         ]
         super().__init__(
             name="pcf",
-            charm="sdcore-pcf_ubuntu-22.04-amd64.charm" if local else "sdcore-pcf",
+            charm="sdcore-pcf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-pcf-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class SMF(Application):
-    """SD-Core SMF Application."""
+    """SD-Core SMF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -127,14 +127,14 @@ class SMF(Application):
         ]
         super().__init__(
             name="smf",
-            charm="sdcore-smf_ubuntu-22.04-amd64.charm" if local else "sdcore-smf",
+            charm="sdcore-smf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-smf-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class UDM(Application):
-    """SD-Core UDM Application."""
+    """SD-Core UDM Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -145,14 +145,14 @@ class UDM(Application):
         ]
         super().__init__(
             name="udm",
-            charm="sdcore-udm_ubuntu-22.04-amd64.charm" if local else "sdcore-udm",
+            charm="sdcore-udm-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-udm-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class UDR(Application):
-    """SD-Core UDR Application."""
+    """SD-Core UDR Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -163,14 +163,14 @@ class UDR(Application):
         ]
         super().__init__(
             name="udr",
-            charm="sdcore-udr_ubuntu-22.04-amd64.charm" if local else "sdcore-udr",
+            charm="sdcore-udr-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-udr-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class UPF(Application):
-    """SD-Core UPF Application."""
+    """SD-Core UPF Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -185,7 +185,7 @@ class UPF(Application):
         ]
         super().__init__(
             name="upf",
-            charm="sdcore-upf_ubuntu-22.04-amd64.charm" if local else "sdcore-upf",
+            charm="sdcore-upf-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-upf-k8s",
             trust=True,
             channel=None if local else channel,
             resources=resources if local else None,
@@ -193,7 +193,7 @@ class UPF(Application):
 
 
 class Webui(Application):
-    """SD-Core Webui Application."""
+    """SD-Core Webui Application for K8s."""
 
     def __init__(self, local: bool, channel: str):
         resources = [
@@ -204,14 +204,14 @@ class Webui(Application):
         ]
         super().__init__(
             name="webui",
-            charm="sdcore-webui_ubuntu-22.04-amd64.charm" if local else "sdcore-webui",
+            charm="sdcore-webui-k8s_ubuntu-22.04-amd64.charm" if local else "sdcore-webui-k8s",
             channel=None if local else channel,
             resources=resources if local else None,
         )
 
 
 class MongoDB(Application):
-    """MongoDB Application."""
+    """MongoDB Application for K8s."""
 
     def __init__(self):
         super().__init__(
@@ -223,7 +223,7 @@ class MongoDB(Application):
 
 
 class GrafanaAgent(Application):
-    """Grafana Agent Application."""
+    """Grafana Agent Application for K8s."""
 
     def __init__(self):
         super().__init__(
@@ -245,7 +245,7 @@ class SelfSignedCertificates(Application):
 
 
 class Traefik(Application):
-    """Traefik Application."""
+    """Traefik Application for K8s."""
 
     def __init__(self):
         super().__init__(

--- a/render_bundle/bundles.py
+++ b/render_bundle/bundles.py
@@ -24,7 +24,7 @@ from lib.charm_bundle_generator import CharmBundle, Relation
 
 
 class SDCore(CharmBundle):
-    """SD-Core Bundle."""
+    """SD-Core Bundle for K8s."""
 
     def __init__(self, local: bool, channel: str):
         amf = AMF(local=local, channel=channel)
@@ -43,8 +43,8 @@ class SDCore(CharmBundle):
         self_signed_certificates = SelfSignedCertificates()
         traefik = Traefik()
         super().__init__(
-            description="The SD-Core bundle contains applications for running a standalone 5G Core network.",  # noqa: E501
-            name="sdcore",
+            description="The SD-Core bundle for K8s which contains applications for running a standalone 5G Core network.",  # noqa: E501
+            name="sdcore-k8s",
             applications=[
                 amf,
                 ausf,
@@ -242,7 +242,7 @@ class SDCore(CharmBundle):
 
 
 class SDCoreControlPlane(CharmBundle):
-    """SD-Core Control Plane Bundle."""
+    """SD-Core Control Plane Bundle for K8s."""
 
     def __init__(self, local: bool, channel: str):
         amf = AMF(local=local, channel=channel)
@@ -260,8 +260,8 @@ class SDCoreControlPlane(CharmBundle):
         self_signed_certificates = SelfSignedCertificates()
         traefik = Traefik()
         super().__init__(
-            description="The SD-Core Control Plane bundle contains the control plane part of the 5G core network.",  # noqa: E501
-            name="sdcore-control-plane",
+            description="The SD-Core Control Plane bundle for K8s which contains the control plane part of the 5G core network.",  # noqa: E501
+            name="sdcore-control-plane-k8s",
             applications=[
                 amf,
                 ausf,
@@ -446,14 +446,14 @@ class SDCoreControlPlane(CharmBundle):
 
 
 class SDCoreUserPlane(CharmBundle):
-    """SD-Core User Plane Bundle."""
+    """SD-Core User Plane Bundle for K8s."""
 
     def __init__(self, local: bool, channel: str):
         upf = UPF(local=local, channel=channel)
         grafana_agent = GrafanaAgent()
         super().__init__(
-            description="The SD-Core User Plane bundle contains the 5G User Plane Function (UPF).",
-            name="sdcore-user-plane",
+            description="The SD-Core User Plane bundle for K8s which contains the 5G User Plane Function (UPF).",  # noqa: E501
+            name="sdcore-user-plane-k8s",
             applications=[
                 upf,
                 grafana_agent,


### PR DESCRIPTION
# Description

Add -k8s as a suffix to sdcore bundles in Charmhub to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
