### PR TITLE
feat: Adding the Terraform module for sdcore-control-plane-k8s bundle

### DIFF
--- a/terraform/sdcore-control-plane-k8s/.gitignore
+++ b/terraform/sdcore-control-plane-k8s/.gitignore
@@ -1,0 +1,37 @@
+.idea/*
+.vscode/*
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+.terraform.lock.hcl

--- a/terraform/sdcore-control-plane-k8s/CONTRIBUTING.md
+++ b/terraform/sdcore-control-plane-k8s/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+## Development environment
+
+### Prerequisites
+
+Make sure the following software and tools are installed in the development
+environment.
+
+- `microk8s`
+- `juju`
+- `terraform`
+
+### Prepare Development Environment
+
+Install Microk8s:
+
+```console
+sudo snap install microk8s --channel=1.27-strict/stable
+sudo usermod -a -G snap_microk8s $USER
+newgrp snap_microk8s
+```
+
+Enable `storage` plugin for Microk8s:
+
+```console
+sudo microk8s enable hostpath-storage
+```
+
+Install Juju:
+
+```console
+sudo snap install juju --channel=3.1/stable
+```
+
+Install Terraform:
+
+```console
+sudo snap install --classic terraform
+```
+
+Bootstrap the Juju Controller using Microk8s:
+
+```console
+juju bootstrap microk8s
+```
+
+### Terraform provider
+
+The Terraform module uses the Juju provider to provision Juju resources. Please refer to the [Juju provider documentation](https://registry.terraform.io/providers/juju/juju/latest/docs) for more information.
+
+A Terraform working directory needs to be initialized at the beginning.
+
+Initialise the provider:
+
+```console
+terraform init
+```
+
+## Testing
+
+Terraform CLI provides various ways to do formatting and validation.
+
+Formats to a canonical format and style:
+
+```console
+terraform fmt
+```
+
+Check the syntactical validation:
+
+```console
+terraform validate
+```
+
+Preview the changes:
+
+```console
+terraform plan
+```

--- a/terraform/sdcore-control-plane-k8s/LICENSE
+++ b/terraform/sdcore-control-plane-k8s/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/terraform/sdcore-control-plane-k8s/README.md
+++ b/terraform/sdcore-control-plane-k8s/README.md
@@ -1,0 +1,64 @@
+# SD-Core Control Plane Terraform Module
+
+This SD-Core Control Plane Terraform module aims to deploy the [sdcore-control-plane-k8s bundle](https://charmhub.io/sdcore-control-plane-k8s) via Terraform.
+
+## Getting Started
+
+### Prerequisites
+
+The following software and tools needs to be installed and should be running in the local environment.
+
+- `microk8s`
+- `juju 3.x`
+- `terrafom`
+
+### Deploy the sdcore-control-plane-k8s bundle using Terraform
+
+Make sure that `storage`, `multus` and `metallb` plugins are enabled for Microk8s:
+
+```console
+sudo microk8s enable hostpath-storage multus
+sudo microk8s enable metallb:10.0.0.2-10.0.0.4
+```
+
+Initialise the provider:
+
+```console
+terraform init
+```
+
+Customize the configuration inputs under `terraform.tfvars` file according to requirement.
+
+Replace the `model-name` value in the `terraform.tfvars` file. The provided model-name is not expected to pre-exist and will be created by Juju Terraform Provider.
+
+```yaml
+model_name =<your model-name>
+```
+
+Run Terraform Plan by providing var-file:
+
+```console
+terraform plan -var-file="terraform.tfvars" 
+```
+
+Deploy the resources, skip the approval:
+
+```console
+terraform apply -auto-approve 
+```
+
+### Check the Output
+
+Run `juju switch <juju model>` to switch to the target Juju model and observe the status of the applications.
+
+```console
+juju status --relations
+```
+
+### Clean up
+
+Remove the applications:
+
+```console
+terraform destroy -auto-approve
+```

--- a/terraform/sdcore-control-plane-k8s/main.tf
+++ b/terraform/sdcore-control-plane-k8s/main.tf
@@ -1,0 +1,166 @@
+resource "juju_model" "sdcore" {
+  name = var.model_name
+}
+
+module "sdcore-amf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-amf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  db_application_name    = module.mongodb-k8s.db_application_name
+  channel                = var.channel
+
+}
+
+module "sdcore-ausf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-ausf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  channel                = var.channel
+}
+
+module "sdcore-nms-k8s" {
+  source                   = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform"
+  model_name               = juju_model.sdcore.name
+  webui_application_name   = module.sdcore-webui-k8s.webui_application_name
+  channel                  = var.channel
+  traefik_application_name = module.traefik-k8s.traefik_application_name
+}
+
+module "sdcore-nrf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  db_application_name    = module.mongodb-k8s.db_application_name
+  channel                = var.channel
+}
+
+module "sdcore-nssf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  channel                = var.channel
+}
+
+module "sdcore-pcf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-pcf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  db_application_name    = module.mongodb-k8s.db_application_name
+  channel                = var.channel
+}
+
+module "sdcore-smf-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-smf-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  db_application_name    = module.mongodb-k8s.db_application_name
+  channel                = var.channel
+}
+
+module "sdcore-udm-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-udm-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  channel                = var.channel
+
+}
+
+module "sdcore-udr-k8s" {
+  source                 = "git::https://github.com/canonical/sdcore-udr-k8s-operator//terraform"
+  model_name             = juju_model.sdcore.name
+  nrf_application_name   = module.sdcore-nrf-k8s.nrf_application_name
+  certs_application_name = module.self-signed-certificates.certs_application_name
+  db_application_name    = module.mongodb-k8s.db_application_name
+  channel                = var.channel
+}
+
+module "sdcore-webui-k8s" {
+  source              = "git::https://github.com/canonical/sdcore-webui-k8s-operator//terraform"
+  model_name          = juju_model.sdcore.name
+  db_application_name = module.mongodb-k8s.db_application_name
+  channel             = var.channel
+}
+
+module "mongodb-k8s" {
+  source     = "git::https://github.com/canonical/mongodb-operator.git//terraform"
+  model_name = juju_model.sdcore.name
+}
+
+module "grafana-agent-k8s" {
+  source     = "git::https://github.com/canonical/grafana-agent-k8s-operator//terraform"
+  model_name = juju_model.sdcore.name
+}
+
+module "self-signed-certificates" {
+  source     = "git::https://github.com/canonical/self-signed-certificates-operator.git//terraform"
+  model_name = juju_model.sdcore.name
+}
+
+module "traefik-k8s" {
+  source     = "git::https://github.com/canonical/traefik-k8s-operator//terraform"
+  model_name = juju_model.sdcore.name
+}
+
+resource "juju_integration" "amf-metrics" {
+  model = juju_model.sdcore.name
+
+  application {
+    name     = module.sdcore-amf-k8s.amf_application_name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    name     = module.grafana-agent-k8s.grafana_application_name
+    endpoint = "metrics-endpoint"
+  }
+}
+
+resource "juju_integration" "smf-metrics" {
+  model = juju_model.sdcore.name
+
+  application {
+    name     = module.sdcore-smf-k8s.smf_application_name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    name     = module.grafana-agent-k8s.grafana_application_name
+    endpoint = "metrics-endpoint"
+  }
+}
+
+resource "juju_integration" "mongo-metrics" {
+  model = juju_model.sdcore.name
+
+  application {
+    name     = module.mongodb-k8s.db_application_name
+    endpoint = "metrics-endpoint"
+  }
+
+  application {
+    name     = module.grafana-agent-k8s.grafana_application_name
+    endpoint = "metrics-endpoint"
+  }
+}
+
+resource "juju_integration" "mongo-logging" {
+  model = juju_model.sdcore.name
+
+  application {
+    name     = module.mongodb-k8s.db_application_name
+    endpoint = "logging"
+  }
+
+  application {
+    name     = module.grafana-agent-k8s.grafana_application_name
+    endpoint = "logging-provider"
+  }
+}
+
+

--- a/terraform/sdcore-control-plane-k8s/terraform.tf
+++ b/terraform/sdcore-control-plane-k8s/terraform.tf
@@ -1,0 +1,11 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.10.1"
+    }
+  }
+}

--- a/terraform/sdcore-control-plane-k8s/variables.tf
+++ b/terraform/sdcore-control-plane-k8s/variables.tf
@@ -1,0 +1,15 @@
+variable "model_name" {
+  description = "Name of Juju model to deploy application to."
+  type        = string
+  default     = ""
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "1.3/edge"
+}
+
+
+
+


### PR DESCRIPTION
# Description

This PR adds the Terraform module for the sdcore-control-plane-k8s bundle. Hence, the bundle could be deployed using Terraform.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
