### PR TITLE
chore: Change interface name from fiveg-nrf to fiveg_nrf

### DIFF
--- a/render_bundle/bundles.py
+++ b/render_bundle/bundles.py
@@ -66,8 +66,8 @@ class SDCore(CharmBundle):
                 Relation(
                     app_1_name=amf.name,
                     app_2_name=nrf.name,
-                    app_1_relation_name="fiveg-nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_1_relation_name="fiveg_nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=amf.name,
@@ -91,7 +91,7 @@ class SDCore(CharmBundle):
                     app_1_name=ausf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=ausf.name,
@@ -133,7 +133,7 @@ class SDCore(CharmBundle):
                     app_1_name=nssf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=nssf.name,
@@ -145,7 +145,7 @@ class SDCore(CharmBundle):
                     app_1_name=pcf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=pcf.name,
@@ -163,7 +163,7 @@ class SDCore(CharmBundle):
                     app_1_name=smf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=smf.name,
@@ -187,7 +187,7 @@ class SDCore(CharmBundle):
                     app_1_name=udm.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=udm.name,
@@ -199,7 +199,7 @@ class SDCore(CharmBundle):
                     app_1_name=udr.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=udr.name,
@@ -282,8 +282,8 @@ class SDCoreControlPlane(CharmBundle):
                 Relation(
                     app_1_name=amf.name,
                     app_2_name=nrf.name,
-                    app_1_relation_name="fiveg-nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_1_relation_name="fiveg_nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=amf.name,
@@ -307,7 +307,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=ausf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=ausf.name,
@@ -343,7 +343,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=nssf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=nssf.name,
@@ -355,7 +355,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=pcf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=pcf.name,
@@ -373,7 +373,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=smf.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=smf.name,
@@ -397,7 +397,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=udm.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=udm.name,
@@ -409,7 +409,7 @@ class SDCoreControlPlane(CharmBundle):
                     app_1_name=udr.name,
                     app_2_name=nrf.name,
                     app_1_relation_name="fiveg_nrf",
-                    app_2_relation_name="fiveg-nrf",
+                    app_2_relation_name="fiveg_nrf",
                 ),
                 Relation(
                     app_1_name=udr.name,

--- a/render_bundle/test-requirements.txt
+++ b/render_bundle/test-requirements.txt
@@ -3,6 +3,7 @@ coverage[toml]
 flake8-docstrings
 flake8-builtins
 isort
+juju==3.3.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming


### PR DESCRIPTION
# Description

- NRF and AMF use different relation names for fiveg_nrf interface. All the other charms uses fiveg_nrf. We need to use the same naming convention in all charms. For this reason interface name is changed from fiveg-nrf -> fiveg_nrf.
- Pinning Juju version to 3.3.0.0. Starting from 3.3.1.0 integration tests are failing.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
