### PR TITLE
chore: Move to codespell and ruff

### DIFF
--- a/render_bundle/lib/charm_bundle_generator.py
+++ b/render_bundle/lib/charm_bundle_generator.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 
 def _write_to_file(file: str, content: str):
-    """Writes content to a file.
+    """Write content to a file.
 
     Args:
         file: File name
@@ -67,7 +67,7 @@ class CharmBundle:
         self.relations = relations
 
     def render(self) -> str:
-        """Renders charm bundle using jinja2 templating.
+        """Render charm bundle using jinja2 templating.
 
         Returns:
             str: Rendered bundle
@@ -84,7 +84,7 @@ class CharmBundle:
         )
 
     def render_to_file(self, output_file: str):
-        """Renders charm bundle using jinja2 templating and outputs to a file.
+        """Render charm bundle using jinja2 templating and outputs to a file.
 
         Args:
             output_file: Output file.

--- a/render_bundle/pyproject.toml
+++ b/render_bundle/pyproject.toml
@@ -9,24 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/render_bundle/render_bundle.py
+++ b/render_bundle/render_bundle.py
@@ -21,7 +21,7 @@ class SDCoreBundleVariant(enum.Enum):
 
 
 def _parse_args() -> tuple[bool, str, str, str]:
-    """Parses user provided arguments.
+    """Parse user provided arguments.
 
     Returns:
         local (bool): Whether to generate a bundle for local charms (instead of charmhub)
@@ -74,7 +74,7 @@ def render_bundle(
     output_file: str,
     channel: Optional[str] = None,
 ):
-    """Generates a SD-Core bundle variant.
+    """Generate a SD-Core bundle variant.
 
     Args:
         local: Whether to use local charms (instead of charmhub).
@@ -88,7 +88,7 @@ def render_bundle(
 
 
 def main():
-    """Generates one of the SD-Core charm bundles based on user provided bundle type."""
+    """Generate one of the SD-Core charm bundles based on user provided bundle type."""
     local, bundle_variant, channel, output_file = _parse_args()
     render_bundle(
         local=local,

--- a/render_bundle/test-requirements.txt
+++ b/render_bundle/test-requirements.txt
@@ -1,15 +1,11 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju==3.4.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/render_bundle/tox.ini
+++ b/render_bundle/tox.ini
@@ -27,15 +27,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]src_path}
-    black {[vars]src_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]src_path}
-    isort --check-only --diff {[vars]src_path}
-    black --check --diff {[vars]src_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. pyproject-flake8 is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
